### PR TITLE
Add Track and Album Support

### DIFF
--- a/lib/ext/BandCamp.ts
+++ b/lib/ext/BandCamp.ts
@@ -35,7 +35,7 @@ export class BandCampExtractor extends BaseExtractor<BandCampExtOpt> {
   ): Promise<ExtractorInfo> {
     if (query.includes("/track/")) {
       const trackSearch = await this.fetchBandcampTrack(query).catch(() => {
-        return this.createResponse();
+        return null;
       });
 
       if (!trackSearch) return this.createResponse();

--- a/lib/ext/BandCamp.ts
+++ b/lib/ext/BandCamp.ts
@@ -1,54 +1,139 @@
-import { BaseExtractor, ExtractorInfo, ExtractorSearchContext, ExtractorStreamable, Track, Util } from "discord-player"
-import bcfetch from "bandcamp-fetch"
+import { Album, BandcampFetch } from "bandcamp-fetch";
+import {
+  BaseExtractor,
+  ExtractorInfo,
+  ExtractorSearchContext,
+  ExtractorStreamable,
+  SearchQueryType,
+  Track,
+  Util,
+} from "discord-player";
 import { bridge } from "../utils/bridge";
-import { isURL } from "../utils/isUrl";
+import { isBandcampURL } from "../utils/isBandcampUrl";
 
 export interface BandCampExtOpt {
-    cookie?: string;
+  cookie?: string;
 }
 
 export class BandCampExtractor extends BaseExtractor<BandCampExtOpt> {
-    static identifier = "com.retrouser955.discord-player.bandcamp" as const
+  readonly bandcampFetch = new BandcampFetch();
+  readonly trackFetcher = this.bandcampFetch.limiter.track;
+  readonly albumFetcher = this.bandcampFetch.limiter.album;
+  readonly bandcampSearch = this.bandcampFetch.limiter.search;
 
-    async activate(): Promise<void> {
-        if(this.options.cookie) {
-            bcfetch.setCookie(this.options.cookie)
+  static identifier = "com.retrouser955.discord-player.bandcamp" as const;
+
+  async activate(): Promise<void> {
+    if (this.options.cookie) {
+      this.bandcampFetch.setCookie(this.options.cookie);
+    }
+  }
+
+  async handle(
+    query: string,
+    context: ExtractorSearchContext
+  ): Promise<ExtractorInfo> {
+    if (!isBandcampURL(query)) {
+      return this.createResponse();
+    }
+
+    if (query.includes("/track/")) {
+      const trackSearch = await this.fetchBandcampTrack(query).catch(() => {
+        return this.createResponse();
+      });
+
+      if (!trackSearch) return this.createResponse();
+
+      return this.createResponse(null, [trackSearch as Track]);
+    } else if (query.includes("/album/")) {
+      const albumSearch: Album = await this.albumFetcher.getInfo({
+        albumUrl: query,
+      });
+
+      if (!albumSearch) return this.createResponse();
+
+      const albumTracks = albumSearch.tracks;
+
+      if (!albumTracks) return this.createResponse();
+
+      const playlistInfo = this.context.player.createPlaylist({
+        author: {
+          name: albumSearch.artist?.name || "Unknown Artist",
+          url: albumSearch.artist?.url || "Unknown URL",
+        },
+        description: albumSearch.description || "No Description",
+        id: albumSearch.id?.toString() || "unknown-id",
+        source: "arbitrary",
+        thumbnail: albumSearch.imageUrl || "",
+        title: albumSearch.name,
+        tracks: [],
+        type: "album",
+        url: albumSearch?.url || "",
+      });
+
+      const fetchedTracks: Track[] = [];
+
+      for (const albumTrack of albumTracks) {
+        if (albumTrack.url) {
+          await this.fetchBandcampTrack(albumTrack.url).then(
+            (bandcampTrack) => {
+              if (!bandcampTrack) return;
+
+              bandcampTrack.playlist = playlistInfo;
+              fetchedTracks.push(bandcampTrack);
+            }
+          );
         }
+      }
+
+      playlistInfo.tracks = fetchedTracks;
+
+      return this.createResponse(playlistInfo, fetchedTracks);
     }
 
-    async handle(query: string, context: ExtractorSearchContext): Promise<ExtractorInfo> {
-        if(isURL(query)) return this.createResponse()
-        const search = await bcfetch.search.tracks({query})
-        if(search.items.length === 0) return this.createResponse()
-        const tracks = await Promise.all(search.items.slice(0, 3).map(async (rawT) => {
-            const item = await bcfetch.track.getInfo({
-                trackUrl: rawT.url
-            })
+    return this.createResponse();
+  }
 
-            const track = new Track(this.context.player, {
-                title: item.name,
-                duration: Util.buildTimeCode(Util.parseMS((item.duration || 0) * 1000)),
-                author: item.artist?.name || "UNKNOWN",
-                raw: rawT,
-                thumbnail: item.imageUrl,
-                source: 'arbitrary',
-                queryType: 'arbitrary',
-                live: false
-            })
-            return track
-        })) // SUCKS! Search is not impressive
-        return this.createResponse(null, tracks)
-        // TODO: IMPLEMENT BANDCAMP URL QUERYING
-        // TODO: IMPLEMENT THIS
-        return this.createResponse() // empty response
+  async bridge(
+    track: Track,
+    sourceExtractor: BaseExtractor | null
+  ): Promise<ExtractorStreamable | null> {
+    try {
+      return bridge(track, sourceExtractor);
+    } catch (error) {
+      this.context.player.debug("Failed due to following error(s)\n" + error);
+      return null;
     }
+  }
 
-    async bridge(track: Track, sourceExtractor: BaseExtractor | null): Promise<ExtractorStreamable | null> {
-        try {
-            return bridge(track, sourceExtractor)
-        } catch (error) {
-            this.context.player.debug("Failed due to following error(s)\n" + error)
-            return null
-        }
-    }
+  async validate(
+    query: string,
+    type?: SearchQueryType | null | undefined
+  ): Promise<boolean> {
+    return isBandcampURL(query);
+  }
+
+  async fetchBandcampTrack(query: string): Promise<Track | undefined> {
+    return await this.trackFetcher
+      .getInfo({ trackUrl: query, includeRawData: true })
+      .then((bandcampTrack) => {
+        if (!bandcampTrack) return;
+
+        const playerTrack = new Track(this.context.player, {
+          title: bandcampTrack.name,
+          duration: Util.buildTimeCode(
+            Util.parseMS((bandcampTrack.duration || 0) * 1000)
+          ),
+          author: bandcampTrack.artist?.name || "Unknown Artist",
+          raw: bandcampTrack,
+          thumbnail: bandcampTrack.imageUrl,
+          source: "arbitrary",
+          queryType: "arbitrary",
+          live: false,
+          url: bandcampTrack.url,
+        });
+
+        return playerTrack;
+      });
+  }
 }

--- a/lib/ext/BandCamp.ts
+++ b/lib/ext/BandCamp.ts
@@ -19,7 +19,6 @@ export class BandCampExtractor extends BaseExtractor<BandCampExtOpt> {
   readonly bandcampFetch = new BandcampFetch();
   readonly trackFetcher = this.bandcampFetch.limiter.track;
   readonly albumFetcher = this.bandcampFetch.limiter.album;
-  readonly bandcampSearch = this.bandcampFetch.limiter.search;
 
   static identifier = "com.retrouser955.discord-player.bandcamp" as const;
 

--- a/lib/ext/BandCamp.ts
+++ b/lib/ext/BandCamp.ts
@@ -71,14 +71,12 @@ export class BandCampExtractor extends BaseExtractor<BandCampExtOpt> {
 
       for (const albumTrack of albumTracks) {
         if (albumTrack.url) {
-          await this.fetchBandcampTrack(albumTrack.url).then(
-            (bandcampTrack) => {
-              if (!bandcampTrack) return;
+          const bandcampTrack = await this.fetchBandcampTrack(albumTrack.url);
 
-              bandcampTrack.playlist = playlistInfo;
-              fetchedTracks.push(bandcampTrack);
-            }
-          );
+          if (!bandcampTrack) continue;
+
+          bandcampTrack.playlist = playlistInfo;
+          fetchedTracks.push(bandcampTrack);
         }
       }
 

--- a/lib/ext/BandCamp.ts
+++ b/lib/ext/BandCamp.ts
@@ -33,10 +33,6 @@ export class BandCampExtractor extends BaseExtractor<BandCampExtOpt> {
     query: string,
     context: ExtractorSearchContext
   ): Promise<ExtractorInfo> {
-    if (!isBandcampURL(query)) {
-      return this.createResponse();
-    }
-
     if (query.includes("/track/")) {
       const trackSearch = await this.fetchBandcampTrack(query).catch(() => {
         return this.createResponse();

--- a/lib/utils/bridge.ts
+++ b/lib/utils/bridge.ts
@@ -1,14 +1,26 @@
+import { BandcampFetch } from "bandcamp-fetch";
 import type { BaseExtractor } from "discord-player";
-import bcfetch from "bandcamp-fetch"
 
-export const bridge: BaseExtractor['bridge'] = async (track, _) => {
-    const query = `${track.author} ${track.source === "youtube" ? track.cleanTitle : track.title}`
+export const bridge: BaseExtractor["bridge"] = async (track, _) => {
+  const matchingTrack = await new BandcampFetch().limiter.track.getInfo({
+    trackUrl: track.url,
+  });
 
-    const search = await bcfetch.search.tracks({query})
-    if(search.items.length === 0) return null
-    const info = await bcfetch.track.getInfo({
-        trackUrl: search.items[0].url
-    })
-    const streamUrl = info.streamUrlHQ || info.streamUrl
-    return streamUrl || null
-}
+  if (!matchingTrack) return null;
+
+  const bandcampUrlTest = await new BandcampFetch().limiter.stream.test(
+    matchingTrack.streamUrlHQ || matchingTrack.streamUrl || ""
+  );
+
+  if (!bandcampUrlTest.ok) {
+    const refreshedUrl = await new BandcampFetch().limiter.stream.refresh(
+      track.url
+    );
+
+    if (!refreshedUrl) return null;
+
+    return refreshedUrl;
+  }
+
+  return matchingTrack.streamUrlHQ || matchingTrack.streamUrl || null;
+};

--- a/lib/utils/isBandcampUrl.ts
+++ b/lib/utils/isBandcampUrl.ts
@@ -1,10 +1,14 @@
-const bandcampRegex = /https:\/\/.*\.bandcamp\.com\//;
+const bandcampTrack = /(^https:)\/\/(www\.)?(.*\.)?bandcamp.com\/track\/.*/;
+const bandcampAlbum = /(^https:)\/\/(www\.)?(.*\.)?bandcamp.com\/album\/.*/;
 
 export function isBandcampURL(query: string) {
   try {
     const parsedURL = new URL(query.trim());
 
-    if (bandcampRegex.test(parsedURL.toString())) {
+    if (
+      bandcampTrack.test(parsedURL.toString()) ||
+      bandcampAlbum.test(parsedURL.toString())
+    ) {
       return true;
     }
   } catch {

--- a/lib/utils/isBandcampUrl.ts
+++ b/lib/utils/isBandcampUrl.ts
@@ -1,14 +1,11 @@
-const bandcampTrack = /(^https:)\/\/(www\.)?(.*\.)?bandcamp.com\/track\/.*/;
-const bandcampAlbum = /(^https:)\/\/(www\.)?(.*\.)?bandcamp.com\/album\/.*/;
+const bandcampURL =
+  /(^https:)\/\/(www\.)?(.*\.)?bandcamp.com\/(track|album)\/.*/;
 
 export function isBandcampURL(query: string) {
   try {
     const parsedURL = new URL(query.trim());
 
-    if (
-      bandcampTrack.test(parsedURL.toString()) ||
-      bandcampAlbum.test(parsedURL.toString())
-    ) {
+    if (bandcampURL.test(parsedURL.toString())) {
       return true;
     }
   } catch {

--- a/lib/utils/isBandcampUrl.ts
+++ b/lib/utils/isBandcampUrl.ts
@@ -1,8 +1,10 @@
+const bandcampRegex = /https:\/\/.*\.bandcamp\.com\//;
+
 export function isBandcampURL(query: string) {
   try {
     const parsedURL = new URL(query.trim());
 
-    if (parsedURL.hostname.endsWith("bandcamp.com")) {
+    if (bandcampRegex.test(parsedURL.toString())) {
       return true;
     }
   } catch {

--- a/lib/utils/isBandcampUrl.ts
+++ b/lib/utils/isBandcampUrl.ts
@@ -1,0 +1,13 @@
+export function isBandcampURL(query: string) {
+  try {
+    const parsedURL = new URL(query.trim());
+
+    if (parsedURL.hostname.endsWith("bandcamp.com")) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}

--- a/lib/utils/isUrl.ts
+++ b/lib/utils/isUrl.ts
@@ -1,8 +1,0 @@
-export function isURL(str: string) {
-    try {
-        new URL(str)
-        return true
-    } catch {
-        return false
-    }
-}


### PR DESCRIPTION
Changelog:
- feat: add track URL support
- feat: add album URL support
- refactor: remove track searching

This PR adds support for extracting albums and tracks from Bandcamp using the bandcamp-fetch library. I've removed the existing track searching functionality as I felt it didn't provide many valuable results. I've also wondered if the `bridge.ts` file can be removed, as I didn't see it utilized (but I'm also not the most familiar with extractors).

Please let me know if you have any questions, concerns, or feedback. Thank you.